### PR TITLE
Expose final paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,21 @@ Also exposed are several readonly attributes for helping in other recipes:
   * `key` - The final path of the key file. i.e. `#{cert_path}/private/#{key_file}`
   * `chain` - The final path of the chain file. i.e. `#{cert_path}/certs/#{chain_file}`
 
+##### Readonly Attribute Example
+
+```rb
+# where node.fqdn = 'example.com'
+tld = certificate_manage 'top_level_domain'
+tld_cert_location = tld.certificate # => /etc/ssl/certs/example.com.pem
+
+# where node.fqdn = 'sub.example.com'
+sbd = certificate_manage 'sub_domain' do
+  cert_path '/bobs/emporium'
+  create_subfolders false
+end
+sbd_cert_location = sbd.key # => /bobs/emporium/sub.example.com.key
+```
+
 #### providers
 
   * `certificate_manage` - The reusable LWRP to manage certificates, keys, and CA bundles

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ The LWRP resource attributes are as follows.
   * `cookbook` - The cookbook containing the erb template, defaults to certificate
   * `create_subfolders` - Enable/disable auto-creation of private/certs subdirectories.  Defaults to true
 
+Also exposed are several readonly attributes for helping in other recipes:
+
+  * `certificate` - The final path of the certificate file. i.e. `#{cert_path}/certs/#{cert_file}`
+  * `key` - The final path of the key file. i.e. `#{cert_path}/private/#{key_file}`
+  * `chain` - The final path of the chain file. i.e. `#{cert_path}/certs/#{chain_file}`
+
 #### providers
 
   * `certificate_manage` - The reusable LWRP to manage certificates, keys, and CA bundles

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -62,3 +62,22 @@ attribute :group, :kind_of => String, :default => 'root'
 
 # Cookbook to search for blank.erb template
 attribute :cookbook, :kind_of => String, :default => 'certificate'
+
+# Accesors for determining where files should be placed
+def certificate
+  bits = [cert_path, cert_file]
+  bits.insert(1, 'certs') if create_subfolders
+  ::File.join(bits)
+end
+
+def key
+  bits = [cert_path, key_file]
+  bits.insert(1, 'private') if create_subfolders
+  ::File.join(bits)
+end
+
+def chain
+  bits = [cert_path, chain_file]
+  bits.insert(1, 'certs') if create_subfolders
+  ::File.join(bits)
+end


### PR DESCRIPTION
Move some path logic into resource to expose final paths. Useful for doing things like this in other recipes:

```rb
cert1 = certificate_manage 'example.com'
where_did_it_go1 = cert1.certificate # => /etc/ssl/certs/example.com.pem

cert2 = certificate_manage 'example.com' do
  cert_path '/bobs/emporium'
  create_subfolders false
end
where_did_it_go2 = cert2.key # => /bobs/emporium/example.com.key
```