### PR TITLE
Replace dots with underscores in search_id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: ruby
 rvm:
   - 1.9.3
 install: bundle install --without integration 
-script: bundle exec rake
+script:
+ - bundle exec rake
+ - bundle exec rspec

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.getchef.com'
+
+metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,10 @@
 source 'https://rubygems.org'
 
+gem 'berkshelf', '~> 3.1'
 gem 'foodcritic', '~> 4.0'
 gem 'knife-solo_data_bag'
 gem 'rubocop'
+gem 'chefspec', '~> 4.0'
 gem 'thor-scmversion'
 
 group :integration do

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -24,16 +24,17 @@ end
 use_inline_resources if defined?(use_inline_resources)
 
 action :create do
+  search_id = new_resource.search_id.gsub('.', '_')
   ssl_secret = Chef::EncryptedDataBagItem.load_secret(new_resource.data_bag_secret)
   ssl_item = nil
   if new_resource.ignore_missing
     begin
-      ssl_item = Chef::EncryptedDataBagItem.load(new_resource.data_bag, new_resource.search_id, ssl_secret)
+      ssl_item = Chef::EncryptedDataBagItem.load(new_resource.data_bag, search_id, ssl_secret)
     rescue
       ssl_item = nil
     end
   else
-    ssl_item = Chef::EncryptedDataBagItem.load(new_resource.data_bag, new_resource.search_id, ssl_secret)
+    ssl_item = Chef::EncryptedDataBagItem.load(new_resource.data_bag, search_id, ssl_secret)
   end
 
   unless ssl_item.nil?

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'certificate::default' do
+  secret_file_path = 'test/integration/default/encrypted_data_bag_secret'
+  before do
+    @secret = Chef::EncryptedDataBagItem.load_secret(secret_file_path)
+    @data_bag_item_content = JSON.parse(IO.read(File.join(File.dirname(__FILE__), '/../test/integration/default/data_bags/certificates/test.json')))
+  end
+
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(step_into: ['certificate_manage']) do |node|
+      node.automatic_attrs['hostname'] = 'example.com'
+      Chef::Config['encrypted_data_bag_secret'] = secret_file_path
+    end.converge(described_recipe)
+  end
+end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -13,4 +13,11 @@ describe 'certificate::default' do
       Chef::Config['encrypted_data_bag_secret'] = secret_file_path
     end.converge(described_recipe)
   end
+
+  it 'Replace dots with underscore in item name to search' do
+    allow(Chef::EncryptedDataBagItem).to receive(:load)
+                                             .with('certificates', 'example_com', @secret)
+                                             .and_return(@data_bag_item_content)
+    expect(chef_run).to create_certificate_manage('example.com')
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+RSpec.configure do |config|
+  config.formatter = :documentation
+  config.color = true
+
+  # Specify the path for Chef Solo to find roles (default: [ascending search])
+  # config.role_path = '/var/roles'
+
+  # Specify the Chef log_level (default: :warn)
+  # config.log_level = :info
+
+  # Specify the path to a local JSON file with Ohai data (default: nil)
+  # config.path = 'ohai.json'
+end
+
+at_exit { ChefSpec::Coverage.report! }


### PR DESCRIPTION
dots are not part of a valid data bag item id.

this make possible to have this.

```ruby
  certificate_manage 'www.example.com' do
    action :create
  end
```

```json
{
   "id": "www_example_com"
}
```

NOTE:
This PR include a rspec case for test this.

So the first commit prepare all the rspec stuf.