### PR TITLE
ChefSpec 4.1 matcher deprecation

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,5 +1,10 @@
 if defined?(ChefSpec)
-  ChefSpec::Runner.define_runner_method :certificate_manage
+  chefspec_version = Gem.loaded_specs['chefspec'].version
+  if chefspec_version < Gem::Version.new('4.1.0')
+    ChefSpec::Runner.define_runner_method :certificate_manage
+  else
+    ChefSpec.define_matcher :certificate_manage
+  end
 
   def create_certificate_manage(resource)
     ChefSpec::Matchers::ResourceMatcher.new(:certificate_manage, :create, resource)


### PR DESCRIPTION
Fixes deprecation warnings with chefspec 4.1.x and above with a backwards compatible solution.

Warning:
```
[DEPRECATION] `ChefSpec::Runner.define_runner_method' is deprecated. It is being used in the certificate_manage resource matcher.Please use `ChefSpec.define_matcher' instead. (called from spec/recipes/_certificates_spec.rb:5:in `block (2 levels) in <top (required)>')
```
Source:
https://github.com/sethvargo/chefspec/blob/master/lib/chefspec/deprecations.rb#L21

Solution inspired by https://github.com/opscode-cookbooks/windows/commit/a413233b59ca475af41d31425ce1f8897433f0b6