### PR TITLE
Add custom data bag type

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,3 +33,13 @@ suites:
         key_file: "test.key"
       }
     ]
+- name: custom
+  run_list: ["recipe[certificate::custom_by_attributes]"]
+  attributes:
+    certificate:
+      cert_file: 'custom_test.pem'
+      key_file: 'custom_test.key'
+      chain_file: 'custom_test_bundle.crt'
+      cert_file_source: '-----BEGIN CERTIFICATE-----\ncertificate\n-----END CERTIFICATE-----'
+      key_file_source: '-----BEGIN KEY-----\nkey\n-----END KEY-----'
+      chain_file_source: '-----BEGIN CERTIFICATE-----\nca_certificate\n-----END CERTIFICATE-----'

--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ Set ID and LWRP attributes to node attribute following...
       },
     ]
 
+### custom_by_attributes  
+
+Set the following node attributes... 
+
+    node['certificate']['cert_file']
+    node['certificate']['key_file']
+    node['certificate']['chain_file']
+    node['certificate']['cert_source']
+    node['certificate']['key_source']
+    node['certificate']['chain_source']
+
+
 
 Resources/Providers
 -------------------
@@ -155,13 +167,16 @@ The LWRP resource attributes are as follows.
 
   * `data_bag` - Data bag index to search, defaults to certificates
   * `data_bag_secret` - Path to the file with the data bag secret
-  * `data_bag_type` - encrypted, unencrypted, vault
+  * `data_bag_type` - encrypted, unencrypted, vault, custom
     - vault type data bags are not supported with chef-solo
   * `search_id` - Data bag id to search for, defaults to provider name
   * `cert_path` - Top-level SSL directory, defaults to vendor specific location
   * `cert_file` - The basename of the x509 certificate, defaults to {node.fqdn}.pem
   * `key_file` - The basename of the private key file, defaults to {node.fqdn}.key
   * `chain_file` - The basename of the x509 certificate, defaults to {node.hostname}-bundle.crt
+  * `cert_source` - The content of the certifcate file when using `custom` data bag type.
+  * `key_source` - The content of the key file when using `custom` data bag type.
+  * `chain_source` - The content of the chain file when using `custom` data bag type.
   * `nginx_cert` - If `true`, combines server and CA certificates for nginx. Default `false`
   * `combined_file` - If `true`, combines server cert, CA cert and private key into a single file. Default `false`
   * `owner` - The file owner, defaults to root
@@ -190,6 +205,34 @@ certificate_manage "mail" do
   group "postfix"
 end
 ```
+
+Here is an example using custom data_bag type. This allows you to use your own data bag structure for certs making it easier to use with exsting data bag solutions. Node attributes or data bag can be used. 
+
+The below will retrieve cert, key and chain from data bag `custom_data_bag` and create. 
+
+```ruby
+certificate_manage "custom_cert" do
+  cert_file 'custom_test.pem'
+  key_file 'custom_test.key'
+  chain_file 'custom_test_bundle.crt'
+  cert_file_source custom_data_bag['cert_file_source]
+  key_file_source custom_data_bag['key_file_source]
+  chain_file_source custom_data_bag['chain_file_source]
+  data_bag_type 'custom'
+end
+```  
+
+The below will delete the specified custom cert and key.
+
+```ruby
+certificate_manage "custom_cert" do
+  cert_file 'custom_test.pem'
+  key_file 'custom_test.key'
+  action :remove
+end
+```  
+
+
 
 ##### .certificate, .key, .chain helper method usage
 

--- a/README.md
+++ b/README.md
@@ -215,9 +215,9 @@ certificate_manage "custom_cert" do
   cert_file 'custom_test.pem'
   key_file 'custom_test.key'
   chain_file 'custom_test_bundle.crt'
-  cert_file_source custom_data_bag['cert_file_source]
-  key_file_source custom_data_bag['key_file_source]
-  chain_file_source custom_data_bag['chain_file_source]
+  cert_file_source custom_data_bag['cert_file_source']
+  key_file_source custom_data_bag['key_file_source']
+  chain_file_source custom_data_bag['chain_file_source']
   data_bag_type 'custom'
 end
 ```  

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -9,4 +9,7 @@ if defined?(ChefSpec)
   def create_certificate_manage(resource)
     ChefSpec::Matchers::ResourceMatcher.new(:certificate_manage, :create, resource)
   end
+    def remove_certificate_manage(resource)
+    ChefSpec::Matchers::ResourceMatcher.new(:certificate_manage, :remove, resource)
+  end
 end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -9,7 +9,8 @@ if defined?(ChefSpec)
   def create_certificate_manage(resource)
     ChefSpec::Matchers::ResourceMatcher.new(:certificate_manage, :create, resource)
   end
-    def remove_certificate_manage(resource)
+
+  def remove_certificate_manage(resource)
     ChefSpec::Matchers::ResourceMatcher.new(:certificate_manage, :remove, resource)
   end
 end

--- a/recipes/custom_by_attributes.rb
+++ b/recipes/custom_by_attributes.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook Name:: certificate
+# Recipe::custom_by_attributes
+#
+# Copyright 2012, Eric G. Wolfe
+#
+# Recipe Information
+# Author: Yukihiko Sawanoborii (HiganWorks LLC)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+certificate_manage 'Install certificate' do
+  cert_file node['certificate']['cert_file']
+  key_file node['certificate']['key_file']
+  chain_file node['certificate']['chain_file']
+  cert_source node['certificate']['cert_file_source']
+  key_source node['certificate']['key_file_source']
+  chain_source node['certificate']['chain_file_source']
+  data_bag_type 'custom'
+end

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -23,7 +23,7 @@ def initialize(*args)
   @sensitive = true
 end
 
-actions :create
+actions :create, :remove
 
 # :data_bag is the Data Bag to search.
 # :data_bag_secret is the path to the file with the data bag secret
@@ -31,7 +31,7 @@ actions :create
 # :search_id is the Data Bag object you wish to search.
 attribute :data_bag, :kind_of => String, :default => 'certificates'
 attribute :data_bag_secret, :kind_of => String, :default => Chef::Config['encrypted_data_bag_secret']
-attribute :data_bag_type, :kind_of => String, :equal_to => ['unencrypted', 'encrypted', 'vault'], :default => 'encrypted'
+attribute :data_bag_type, :kind_of => String, :equal_to => %w(unencrypted encrypted vault custom), :default => 'encrypted'
 attribute :search_id, :kind_of => String, :name_attribute => true
 attribute :ignore_missing, :kind_of => [TrueClass, FalseClass], :default => false
 
@@ -58,6 +58,14 @@ attribute :cert_file, :kind_of => String, :default => "#{node['fqdn']}.pem"
 attribute :key_file, :kind_of => String, :default => "#{node['fqdn']}.key"
 attribute :chain_file, :kind_of => String, :default => "#{node['hostname']}-bundle.crt"
 attribute :create_subfolders, :kind_of => [TrueClass, FalseClass], :default => true
+
+# Custom only attributes
+# :cert_file_source is the content of the certifcate file.
+# :key_file_source is the content of the key file.
+# :chain_file_source is the content of the chain file.
+attribute :cert_source, :kind_of => String, :default => nil
+attribute :key_source, :kind_of => String, :default => nil
+attribute :chain_source, :kind_of => String, :default => nil
 
 # The owner and group of the managed certificate and key
 attribute :owner, :kind_of => String, :default => 'root'


### PR DESCRIPTION
Hi,

I was in the process of writing my own certificate cookbook and one of my colleagues pointed me to yours. I believe he met you recently at a Chef summit or similar. He told me you were keen for the community to contribute.

This PR add the data bag type `custom' which allows me to handle how I store and retrieve the certificates. I have quite a few scenarios where there is an existing data bag structure that does not meet your cookbook requirements.

I did submit a PR previously but decided it was more complicated than it needed to be and was in effect a rewrite. https://github.com/atomic-penguin/cookbook-certificate/pull/48

Have a look and let me know your thoughts on this. I'm keen to keep on using your cookbook but I do need the flexibility of my own data bag structure.

The resource will be as follows:

```
certificate_manage 'Install certificate' do
  cert_file custom_data_bag['cert_name']
  key_file custom_data_bag['key_name']
  chain_file custom_data_bag['chain_file_bundle']
  cert_file_source custom_data_bag['cert_file_source']
  key_file_source custom_data_bag['key_file_source']
  chain_file_source custom_data_bag['chain_file_source']
  data_bag_type 'custom'
end
```

I've also added a remove action to delete certificates
